### PR TITLE
Some improvements for plasma-drawer

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -23,8 +23,12 @@
       <label>The size of the icons in the applications grid</label>
       <default>128</default>
     </entry>
-    <entry name="appLabelPointSize" type="Double">
-      <label>Label size of application entry (point size)</label>
+    <entry name="useCustomFontSize" type="Bool">
+      <label>Whether to use user-defined font size instead of an font size in system configuration.</label>
+      <default>false</default>
+    </entry>
+    <entry name="fontPointSize" type="Double">
+      <label>The font size of almost all labels (point size)</label>
       <default>12.0</default>
     </entry>
     <entry name="maxNumberColumns" type="Int">

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -23,6 +23,10 @@
       <label>The size of the icons in the applications grid</label>
       <default>128</default>
     </entry>
+    <entry name="appLabelPointSize" type="Double">
+      <label>Label size of application entry (point size)</label>
+      <default>12.0</default>
+    </entry>
     <entry name="maxNumberColumns" type="Int">
       <label>The max number of columns in the applications grid</label>
       <default>5</default>

--- a/contents/ui/ConfigGeneral.qml
+++ b/contents/ui/ConfigGeneral.qml
@@ -37,7 +37,8 @@ Kirigami.FormLayout {
     property alias cfg_disableAnimations:       disableAnimations.checked
 
     property int cfg_appIconSize:               plasmoid.configuration.appIconSize
-    property alias cfg_appLabelPointSize:       appLabelPointSize.value
+    property alias cfg_useCustomFontSize:       useCustomFontSize.checked
+    property alias cfg_fontPointSize:           fontPointSize.value
     property alias cfg_useDirectoryIcons:       useDirectoryIcons.checked
     property alias cfg_maxNumberColumns:        maxNumberColumns.value
 
@@ -173,6 +174,25 @@ Kirigami.FormLayout {
     }
 
     CheckBox {        
+        id: useCustomFontSize
+        text:  i18n("Use user-defined font size")
+    }
+
+    RowLayout {
+        Layout.fillWidth: true
+        
+        Label {
+            text: i18n("Font size of labels (point size):")
+        }
+        
+        SpinBox{
+            id: fontPointSize
+            from: 1
+            to: 128
+        }
+    }
+
+    CheckBox {        
         id: disableAnimations
         text:  i18n("Disable animations")
     }
@@ -222,20 +242,6 @@ Kirigami.FormLayout {
         }
     }
     
-    RowLayout {
-        Layout.fillWidth: true
-        
-        Label {
-            text: i18n("Label size of application entry (point size):")
-        }
-        
-        SpinBox{
-            id: appLabelPointSize
-            from: 1
-            to: 128
-        }
-    }
-
     CheckBox {        
         id: useDirectoryIcons
         text:  i18n("Use directory icons")

--- a/contents/ui/ConfigGeneral.qml
+++ b/contents/ui/ConfigGeneral.qml
@@ -37,6 +37,7 @@ Kirigami.FormLayout {
     property alias cfg_disableAnimations:       disableAnimations.checked
 
     property int cfg_appIconSize:               plasmoid.configuration.appIconSize
+    property alias cfg_appLabelPointSize:       appLabelPointSize.value
     property alias cfg_useDirectoryIcons:       useDirectoryIcons.checked
     property alias cfg_maxNumberColumns:        maxNumberColumns.value
 
@@ -218,6 +219,20 @@ Kirigami.FormLayout {
             Component.onCompleted: {
                 currentIndex = model.findIndex((size) => size == cfg_appIconSize);
             }
+        }
+    }
+    
+    RowLayout {
+        Layout.fillWidth: true
+        
+        Label {
+            text: i18n("Label size of application entry (point size):")
+        }
+        
+        SpinBox{
+            id: appLabelPointSize
+            from: 1
+            to: 128
         }
     }
 

--- a/contents/ui/ItemGridDelegate.qml
+++ b/contents/ui/ItemGridDelegate.qml
@@ -179,6 +179,7 @@ Item {
         wrapMode: Text.NoWrap
 
         text: model.display
+        font.pointSize: plasmoid.configuration.appLabelPointSize
     }
 
     // PlasmaComponents.Label {

--- a/contents/ui/ItemGridDelegate.qml
+++ b/contents/ui/ItemGridDelegate.qml
@@ -179,7 +179,7 @@ Item {
         wrapMode: Text.NoWrap
 
         text: model.display
-        font.pointSize: plasmoid.configuration.appLabelPointSize
+        font.pointSize: fontPointSize
     }
 
     // PlasmaComponents.Label {

--- a/contents/ui/ItemGridView.qml
+++ b/contents/ui/ItemGridView.qml
@@ -329,7 +329,8 @@ FocusScope {
                     property int pressX: -1
                     property int pressY: -1
 
-                    acceptedButtons: Qt.LeftButton | Qt.RightButton
+                    // Append Qt.BackButton to allow this control to catch Mouse Back Button
+                    acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.BackButton
 
                     enabled: itemGrid.enabled
                     hoverEnabled: enabled
@@ -358,6 +359,13 @@ FocusScope {
 
                     onReleased: {
                         mouse.accepted = true;
+                        
+                        // Click Mouse back button (side button) to move back.
+                        if (mouse.button == Qt.BackButton){
+                            root.leave();
+                            return;
+                        }
+                        
                         if (gridView.currentItem) {
                             itemGrid.trigger(gridView.currentIndex);
                         } else if (!dragHelper.dragging) {

--- a/contents/ui/ItemGridView.qml
+++ b/contents/ui/ItemGridView.qml
@@ -362,7 +362,7 @@ FocusScope {
 
                         // Click Mouse back button (side button) event handler.
                         if (mouse.button == Qt.BackButton){
-                            handleBackButton();
+                            backOrClose();
                             return;
                         }
                                                 

--- a/contents/ui/ItemGridView.qml
+++ b/contents/ui/ItemGridView.qml
@@ -329,7 +329,7 @@ FocusScope {
                     property int pressX: -1
                     property int pressY: -1
 
-                    // Append Qt.BackButton to allow this control to catch Mouse Back Button
+                    // Append Qt.BackButton to allow this area to catch Mouse Back Button
                     acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.BackButton
 
                     enabled: itemGrid.enabled
@@ -359,13 +359,13 @@ FocusScope {
 
                     onReleased: {
                         mouse.accepted = true;
-                        
-                        // Click Mouse back button (side button) to move back.
+
+                        // Click Mouse back button (side button) event handler.
                         if (mouse.button == Qt.BackButton){
-                            root.leave();
+                            handleBackButton();
                             return;
                         }
-                        
+                                                
                         if (gridView.currentItem) {
                             itemGrid.trigger(gridView.currentIndex);
                         } else if (!dragHelper.dragging) {

--- a/contents/ui/ItemListDelegate.qml
+++ b/contents/ui/ItemListDelegate.qml
@@ -61,5 +61,6 @@ Item {
         wrapMode: Text.Wrap
 
         text: model.display
+        font.pointSize: plasmoid.configuration.appLabelPointSize
     }
 }

--- a/contents/ui/ItemListDelegate.qml
+++ b/contents/ui/ItemListDelegate.qml
@@ -61,6 +61,6 @@ Item {
         wrapMode: Text.Wrap
 
         text: model.display
-        font.pointSize: plasmoid.configuration.appLabelPointSize
+        font.pointSize: fontPointSize
     }
 }

--- a/contents/ui/ItemListView.qml
+++ b/contents/ui/ItemListView.qml
@@ -189,7 +189,9 @@ FocusScope {
 
                 enabled: itemList.enabled
                 hoverEnabled: enabled
-                acceptedButtons: Qt.LeftButton | Qt.RightButton
+
+                // Append Qt.BackButton to allow this area to catch Mouse Back Button
+                acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.BackButton
 
                 function updatePositionProperties(x, y) {
                     var cPos = mapToItem(contentItem, x, y);
@@ -206,6 +208,13 @@ FocusScope {
                 }
 
                 onReleased: {
+                    // Click Mouse back button (side button) event handler.
+                    if (mouse.button == Qt.BackButton){
+                        mouse.accepted = true;
+                        handleBackButton();
+                        return;
+                    }
+
                     if (mouse.button != Qt.RightButton && currentIndex != -1) {
                         mouse.accepted = true;
                         itemList.trigger(currentIndex);

--- a/contents/ui/ItemListView.qml
+++ b/contents/ui/ItemListView.qml
@@ -211,7 +211,7 @@ FocusScope {
                     // Click Mouse back button (side button) event handler.
                     if (mouse.button == Qt.BackButton){
                         mouse.accepted = true;
-                        handleBackButton();
+                        backOrClose();
                         return;
                     }
 

--- a/contents/ui/MenuRepresentation.qml
+++ b/contents/ui/MenuRepresentation.qml
@@ -99,7 +99,9 @@ Kicker.DashboardWindow {
     mainItem: MouseArea {
         id: rootMouseArea
         anchors.fill: parent
-        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        
+        // Append Qt.BackButton to allow this control to catch Mouse Back Button
+        acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.BackButton
         LayoutMirroring.enabled: Qt.application.layoutDirection == Qt.RightToLeft
         LayoutMirroring.childrenInherit: true
         // hoverEnabled: true
@@ -117,6 +119,13 @@ Kicker.DashboardWindow {
 
         onReleased: {
             mouse.accepted = true;
+            
+            // Click Mouse back button (side button) to move back.
+            if (mouse.button == Qt.BackButton){
+                root.leave();
+                return;
+            }
+            
             if (mouse.button == Qt.RightButton) {
                 if (!searching) {
                     root.openActionMenu(mouse.x, mouse.y);
@@ -259,6 +268,8 @@ Kicker.DashboardWindow {
                 numberColumns: Math.min(plasmoid.configuration.maxNumberColumns, Math.floor((root.width - units.largeSpacing * 2) / cellSizeWidth))
 
                 model: appsModel
+                
+                
             }
         }
 

--- a/contents/ui/MenuRepresentation.qml
+++ b/contents/ui/MenuRepresentation.qml
@@ -268,8 +268,6 @@ Kicker.DashboardWindow {
                 numberColumns: Math.min(plasmoid.configuration.maxNumberColumns, Math.floor((root.width - units.largeSpacing * 2) / cellSizeWidth))
 
                 model: appsModel
-                
-                
             }
         }
 

--- a/contents/ui/MenuRepresentation.qml
+++ b/contents/ui/MenuRepresentation.qml
@@ -37,6 +37,7 @@ Kicker.DashboardWindow {
     id: root
 
     property int topBottomContentMargin: Math.max(units.iconSizes.huge, height * .15)
+    readonly property double fontPointSize: plasmoid.configuration.useCustomFontSize ? plasmoid.configuration.fontPointSize : theme.defaultFont.pointSize
 
     // keyEventProxy: searchField
     backgroundColor: "transparent"
@@ -88,9 +89,9 @@ Kicker.DashboardWindow {
     }
 
     // Use this function to handle back button event.
-    function handleBackButton() {
+    function backOrClose() {
         // When search query is not empty, clear it instead.
-        if(searchField.text != ""){
+        if(searching){
             reset();
             return;
         }
@@ -134,7 +135,7 @@ Kicker.DashboardWindow {
             
             // Click Mouse back button (side button) to move back.
             if (mouse.button == Qt.BackButton){
-                handleBackButton();
+                backOrClose();
                 return;
             }
             

--- a/contents/ui/MenuRepresentation.qml
+++ b/contents/ui/MenuRepresentation.qml
@@ -87,6 +87,18 @@ Kicker.DashboardWindow {
         content.focus = true;
     }
 
+    // Use this function to handle back button event.
+    function handleBackButton() {
+        // When search query is not empty, clear it instead.
+        if(searchField.text != ""){
+            reset();
+            return;
+        }
+
+        root.leave();
+        return;
+    }
+
     function openActionMenu(x, y, actionList = undefined) {
         if (actionList) {
             actionMenu.actionList = actionList;
@@ -122,7 +134,7 @@ Kicker.DashboardWindow {
             
             // Click Mouse back button (side button) to move back.
             if (mouse.button == Qt.BackButton){
-                root.leave();
+                handleBackButton();
                 return;
             }
             

--- a/contents/ui/RunnerResultsView.qml
+++ b/contents/ui/RunnerResultsView.qml
@@ -172,7 +172,7 @@ FocusScope {
 
                             onReleased: {
                                 mouse.accepted = true;
-                                handleBackButton();
+                                backOrClose();
                                 return;
                             }
                         }
@@ -192,6 +192,8 @@ FocusScope {
                             verticalAlignment: Text.AlignBottom
                             text: matchesList.expanded ? i18n("Show Less") : i18n("Show More")
                             color: Qt.darker(theme.disabledTextColor, showMoreButton.hovered ? 1.5: 1);
+                            // https://github.com/P-Connor/plasma-drawer/pull/48
+                            font.pointSize: fontPointSize
                         }
                         background: Rectangle {         
                             id: showMoreButtonHighlight

--- a/contents/ui/RunnerResultsView.qml
+++ b/contents/ui/RunnerResultsView.qml
@@ -164,6 +164,18 @@ FocusScope {
                     PlasmaExtras.Heading {
                         id: runnerName
                         
+                        // This MouseArea is used for handle mouse back button 
+                        // click event on search result heading area
+                        MouseArea {
+                            anchors.fill: parent
+                            acceptedButtons: Qt.BackButton
+
+                            onReleased: {
+                                mouse.accepted = true;
+                                handleBackButton();
+                                return;
+                            }
+                        }
                         text: model.display ?? ""
                         level: 2
                     }


### PR DESCRIPTION
In this PR will improve plasma-drawer for a bit. You can use mouse back button to navigate to previous level of view or close drawer, if you are on main level of drawer. Also I added an option to allow you adjust text size of label of all application entry (including grid view and search result list item) to make them more easily to read.
### added features:
+ Use Mouse Back button (side button usually) to navigate back or close drawer easily.
+ Adjustable label text point size (Grid item and List item while in search state), uses `font.pointSize` [Qt Docs](https://doc.qt.io/qt-5/qml-qtquick-text.html#font.pointSize-prop). Its able to change in "Configure Plasma Drawer" -> "Label size of application entry (point size)". Default value is `12`.

Tested on Debian bookworm, KDE Plasma 5.26.90, KDE Framework 5.103.0, Qt 5.15.8.

### Screenshots (12 point size of text, 1920x1080)
![Screenshot_20230226_021849](https://user-images.githubusercontent.com/38249047/221370877-180b4335-71a8-4d43-a42e-2ebdf5602fa1.png)
![Screenshot_20230226_022100](https://user-images.githubusercontent.com/38249047/221370871-6e45ccd9-07c2-453f-a9f3-e3f87cbdcb78.png)
![Screenshot_20230226_021905](https://user-images.githubusercontent.com/38249047/221370876-a20be13f-bb26-465d-9f79-a88e804276eb.png)

### Screenshots (16 point size of text, 1920x1080)
![Screenshot_20230226_021918](https://user-images.githubusercontent.com/38249047/221370919-f73aa38b-5a5c-4021-9c32-4155c00dde41.png)
![Screenshot_20230226_022044](https://user-images.githubusercontent.com/38249047/221370914-a1bd9ea6-5ac0-4ab9-93bc-37a8e294846f.png)
![Screenshot_20230226_021925](https://user-images.githubusercontent.com/38249047/221370916-b79f1848-ec81-40ae-a71e-bd46e85c0e1b.png)

Lacks on my knowledge of Qt Quick development skills, I can't solve some open issues at this moment. I use this plugin every day and its useful to me. I want to improve it to make it stronger than before. Feel free to ask any question about this PR.